### PR TITLE
chore: export ByteConversion

### DIFF
--- a/voxelis/src/core/mod.rs
+++ b/voxelis/src/core/mod.rs
@@ -10,4 +10,4 @@ pub use block_id::BlockId;
 pub use lod::Lod;
 pub use max_depth::MaxDepth;
 pub use traversal_depth::TraversalDepth;
-pub use voxel::VoxelTrait;
+pub use voxel::{ByteConversion, VoxelTrait};


### PR DESCRIPTION
I probably should have started with this change as it's a tad smaller. Thanks in advance for the review!

## What
The `ByteConversion` trait is currently hidden behind `core::voxel`. Exposing it enables Voxelis users to have typed voxel values for convenience and clarity.

### Question
I wasn't really sure where to put the export. I ended up making the minimal change to expose ByteConversion in `core`, because `core` is public and there are other symbols exposed there. On the other hand, `VoxelTrait` is exposed at the top level out of core and you need both to implement a voxel type. I'm not really clear on what namespace it belongs in and will happily move it wherever you think it should go. 

### Example
With this patch, I'm using an [enum MatId](https://codeberg.org/TrainedMonkeyStudios/disjoin/src/commit/bc0b04037670f17c7e7796007569cf0416307ad7/crates/worldgen_common/src/material.rs#L34) as the inner type for `VoxInterner<MatId>`, `VoxChunk<MatId>`, etc. This is much clearer and allows me to easily hang an entire material system off of the voxel grid.
